### PR TITLE
+windows support

### DIFF
--- a/bind/einhorn.go
+++ b/bind/einhorn.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package bind
 
 import (

--- a/bind/einhorn_windows.go
+++ b/bind/einhorn_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package bind
+
+import (
+	"net"
+)
+
+func einhornInit()                             {}
+func einhornAck()                              {}
+func einhornBind(fd int) (net.Listener, error) { return nil, nil }
+func usingEinhorn() bool                       { return false }

--- a/bind/systemd.go
+++ b/bind/systemd.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package bind
 
 import (

--- a/bind/systemd_windows.go
+++ b/bind/systemd_windows.go
@@ -1,0 +1,6 @@
+// +build windows
+
+package bind
+
+func systemdInit()       {}
+func usingSystemd() bool { return false }

--- a/graceful/einhorn.go
+++ b/graceful/einhorn.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package graceful
 
 import (


### PR DESCRIPTION
Hi, again!
I've changed a few files to make goji compilable and usable on windows by basically stubbing out parts that are einhorn/systemd-related - as I'd really like to use the original repository! I'm developing on windows (where it is a problem) and deploy to heroku (where it isn't) - my first stab was to fork, but with a fork I had to change the package paths which is not ideal.

Thanks!
dmitri.
