### PR TITLE
HTTP Basic Authentication middleware (inc. simple tests!)

### DIFF
--- a/web/middleware/basic_auth.go
+++ b/web/middleware/basic_auth.go
@@ -1,0 +1,119 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/zenazn/goji/web"
+	"net/http"
+	"strings"
+)
+
+type basicAuth struct {
+	h    http.Handler
+	c    *web.C
+	opts *AuthOptions
+}
+
+// AuthOptions stores the configuration for HTTP Basic Authentication.
+//
+// The Realm (scope/namespace), User and Password must be supplied.
+// A http.Handler may also be passed to UnauthorizedHandler to override the
+// default error handler if you wish to serve a custom template/response.
+type AuthOptions struct {
+	Realm               string
+	User                string
+	Password            string
+	UnauthorizedHandler http.Handler
+}
+
+// Satisfies the http.Handler interface for basicAuth.
+func (b basicAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Check if we have a user-provided error handler, else set a default
+	if b.opts.UnauthorizedHandler == nil {
+		b.opts.UnauthorizedHandler = http.HandlerFunc(defaultUnauthorizedHandler)
+		return
+	}
+
+	if b.authenticate(r) == false {
+		b.requestAuth(w, r)
+		return
+	}
+
+	// Call the next handler on success.
+	b.h.ServeHTTP(w, r)
+}
+
+// authenticate validates the user:password combination provided in the request header.
+// Returns 'false' if the user has not successfully authenticated.
+func (b *basicAuth) authenticate(r *http.Request) bool {
+	// Confirm the request is sending Basic Authentication credentials.
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "Basic ") {
+        return false
+	}
+
+	// Get the plain-text username and password from the request
+	// The first six characters are skipped e.g. "Basic ".
+	str, err := base64.StdEncoding.DecodeString(auth[6:])
+	if err != nil {
+		return false
+	}
+
+	// Split on the first ":" character only, with any subsequent colons assumed to be part
+	// of the password. Note that the RFC2617 standard does not place any limitations on
+	// allowable characters in the password.
+	creds := strings.SplitN(string(str), ":", 2)
+	// Validate the user & password match.
+	if creds[0] == b.opts.User && creds[1] == b.opts.Password {
+		return true
+	}
+
+	return false
+}
+
+// Require authentication, and serve our error handler otherwise.
+func (b *basicAuth) requestAuth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s"`, b.opts.Realm))
+	b.opts.UnauthorizedHandler.ServeHTTP(w, r)
+}
+
+// defaultUnauthorizedHandler provides a default HTTP 401 Unauthorized response.
+func defaultUnauthorizedHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(401)
+	w.Write([]byte("You are not authorized to access this resource."))
+}
+
+// BasicAuth provides HTTP middleware for protecting URIs with HTTP Basic Authentication
+// as per RFC 2617. The server authenticates a user:password combination provided in the
+// "Authorization" HTTP header.
+//
+// Example:
+//
+//     package main
+//
+//     import(
+//            "net/http"
+//            "github.com/zenazn/goji/web"
+//            "github.com/zenazn/goji/web/middleware"
+//     )
+//
+//     func main() {
+//          basicOpts := &middleware.AuthOptions{
+//                      Realm: "Restricted",
+//                      User: "Dave",
+//                      Password: "ClearText",
+//                  }
+//
+//          goji.Use(middleware.BasicAuth(basicOpts), middleware.SomeOtherMiddleware)
+//          goji.Get("/thing", myHandler)
+//  }
+//
+// Note: HTTP Basic Authentication credentials are sent in plain text, and therefore it does
+// not make for a wholly secure authentication mechanism. You should serve your content over
+// HTTPS to mitigate this, noting that "Basic Authentication" is meant to be just that: basic!
+func BasicAuth(o *AuthOptions) func(*web.C, http.Handler) http.Handler {
+	fn := func(c *web.C, h http.Handler) http.Handler {
+		return basicAuth{h, c, o}
+	}
+	return fn
+}

--- a/web/middleware/basic_auth_test.go
+++ b/web/middleware/basic_auth_test.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+)
+
+func TestBasicAuthAuthenticate(t *testing.T) {
+	// Provide a minimal test implementation.
+	b := &basicAuth{
+		opts: &AuthOptions{
+			Realm:    "Restricted",
+			User:     "test",
+			Password: "test123",
+		},
+	}
+
+	r := &http.Request{}
+	r.Method = "GET"
+
+	// Provide auth data, but no Authorization header
+	if b.authenticate(r) != false {
+		t.Fatal("No Authorization header supplied.")
+	}
+
+	// Initialise the map for HTTP headers
+	r.Header = http.Header(make(map[string][]string))
+
+	// Set a malformed/bad header
+	r.Header.Set("Authorization", "    Basic")
+	if b.authenticate(r) != false {
+		t.Fatal("Malformed Authorization header supplied.")
+	}
+
+    // Test correct credentials
+    auth := base64.StdEncoding.EncodeToString([]byte(b.opts.User + ":" + b.opts.Password))
+	r.Header.Set("Authorization", "Basic " + auth)
+	if b.authenticate(r) != true {
+		t.Fatal("Failed on correct credentials")
+	}
+}


### PR DESCRIPTION
Hi,

On my way to implementing some CSRF middleware I figured I'd push out some HTTP Basic Authentication middleware (plus I wanted to validate the approach we discussed in https://github.com/zenazn/goji/issues/23).

A quick example:

``` go
// Establish our authentication settings
authOpts := &middleware.AuthOptions{
        Realm: "Restricted",
        User: "matt",
        Password: "if-its-http-its-plaintext",
}

// Add the middleware to the stack.
goji.Use(middleware.BasicAuth(authOpts))

// Your router is now 'protected' with HTTP Basic Auth.
goji.Get("/", myHandler)
```

There's some minimal tests included, to which I'll add a few more cases if you're happy with the overall approach. `AuthOptions` also allows a package user to pass in a custom `UnauthorizedHandler` if they wish to serve their own custom 401 page.
