### PR TITLE
Fixing typo in example README.

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -5,6 +5,6 @@ Gritter is an example application built using Goji, where people who have
 nothing better to do can post short 140-character "greets."
 
 A good place to start is with `main.go`, which contains a well-commented
-walthrough of Goji's features. Gritter uses a couple custom middlewares, which
+walkthrough of Goji's features. Gritter uses a couple custom middlewares, which
 have been arbitrarily placed in `middleware.go`. Finally some uninteresting
 "database models" live in `models.go`.


### PR DESCRIPTION
Should be `walkthrough`, not `walthrough` (although going through walls would be pretty cool).
