### PR TITLE
Record matched pattern in context as web.C.Pattern.

### DIFF
--- a/web/pattern.go
+++ b/web/pattern.go
@@ -205,6 +205,7 @@ func (s stringPattern) match(r *http.Request, c *C, dryrun bool) bool {
 		return true
 	}
 
+	c.Pattern = s.raw
 	if c.URLParams == nil {
 		c.URLParams = matches
 	} else {

--- a/web/web.go
+++ b/web/web.go
@@ -99,6 +99,8 @@ type C struct {
 	// capture is used, it will be assigned to the special identifiers "$1",
 	// "$2", etc.
 	URLParams map[string]string
+	// The pattern that was matched.
+	Pattern string
 	// A free-form environment, similar to Rack or PEP 333's environments.
 	// Middleware layers are encouraged to pass data to downstream layers
 	// and other handlers using this map, and are even more strongly


### PR DESCRIPTION
This makes the matched StringPattern available to method handlers and to loggers.
