### PR TITLE
Move signal logging to the PostHook.

### DIFF
--- a/graceful/signal.go
+++ b/graceful/signal.go
@@ -1,7 +1,6 @@
 package graceful
 
 import (
-	"log"
 	"os"
 	"os/signal"
 	"sync"
@@ -90,8 +89,7 @@ func PostHook(f func()) {
 }
 
 func waitForSignal() {
-	sig := <-sigchan
-	log.Printf("Received %v, gracefully shutting down!", sig)
+	_ = <-sigchan
 
 	hookLock.Lock()
 	defer hookLock.Unlock()

--- a/serve.go
+++ b/serve.go
@@ -33,6 +33,7 @@ func Serve() {
 
 	graceful.HandleSignals()
 	bind.Ready()
+	graceful.PostHook(func() { log.Printf("Goji gracefully stopping") })
 
 	err := graceful.Serve(listener, http.DefaultServeMux)
 


### PR DESCRIPTION
This change lets people use a custom logger without getting extraneous output on signals.

It also serves as a demo in how to use the hook functions. :)
