### PR TITLE
Guard waitgroup access with a mutex to prevent race.

### DIFF
--- a/graceful/net.go
+++ b/graceful/net.go
@@ -58,7 +58,10 @@ func WrapConn(c net.Conn) net.Conn {
 		return nil
 	}
 
+	wgLock.Lock()
+	defer wgLock.Unlock()
 	wg.Add(1)
+
 	return &conn{
 		Conn: c,
 		id:   atomic.AddUint64(&idleSet.id, 1),

--- a/graceful/signal.go
+++ b/graceful/signal.go
@@ -17,6 +17,7 @@ var wait = make(chan struct{})
 // This is the WaitGroup that indicates when all the connections have gracefully
 // shut down.
 var wg sync.WaitGroup
+var wgLock sync.Mutex
 
 // This lock protects the list of pre- and post- hooks below.
 var hookLock sync.Mutex
@@ -99,6 +100,8 @@ func waitForSignal() {
 	}
 
 	close(kill)
+	wgLock.Lock()
+	defer wgLock.Unlock()
 	wg.Wait()
 
 	for _, f := range posthooks {


### PR DESCRIPTION
Running my application with 'go run -race ...' always reports a race condition at exit if any requests have been served.

I can't say for certain that it was a problem, but this fixes it.

It's better to have no spurious error messages, to avoid the habit of ignoring them.
