### PR TITLE
Gracefully shut down on SIGTERM

### DIFF
--- a/graceful/signal.go
+++ b/graceful/signal.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 )
 
 // This is the channel that the connections select on. When it is closed, the
@@ -23,7 +24,7 @@ var hookLock sync.Mutex
 var prehooks = make([]func(), 0)
 var posthooks = make([]func(), 0)
 
-var stdSignals = []os.Signal{os.Interrupt}
+var stdSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
 var sigchan = make(chan os.Signal, 1)
 
 func init() {


### PR DESCRIPTION
Currently, Goji shuts down gracefully on a keyboard interrupt (Ctrl+C, SIGINT).

However, during OS system shutdown all processes receive a preliminary SIGTERM prior to being terminated with extreme prejudice. Goji does not handle the SIGTERM, and is therefore killed immediately.

This patch adds handling for SIGTERM, to permit graceful shutdown on system exit (or by standard init scripts).