### PR TITLE
Added support for wildcard/subrouter when using regexp pattern

### DIFF
--- a/web/regexp_pattern.go
+++ b/web/regexp_pattern.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"regexp"
 	"regexp/syntax"
+	"strings"
 )
 
 type regexpPattern struct {
@@ -42,7 +43,9 @@ func (p regexpPattern) match(r *http.Request, c *C, dryrun bool) bool {
 		c.URLParams[p.names[i]] = matches[i]
 	}
 
-	c.URLParams["*"] = p.re.ReplaceAllString(r.URL.Path, "")
+	if !strings.HasSuffix(p.re.String(), "$") {
+		c.URLParams["*"] = p.re.ReplaceAllString(r.URL.Path, "")
+	}
 
 	return true
 }

--- a/web/regexp_pattern.go
+++ b/web/regexp_pattern.go
@@ -41,6 +41,9 @@ func (p regexpPattern) match(r *http.Request, c *C, dryrun bool) bool {
 	for i := 1; i < len(matches); i++ {
 		c.URLParams[p.names[i]] = matches[i]
 	}
+
+	c.URLParams["*"] = p.re.ReplaceAllString(r.URL.Path, "")
+
 	return true
 }
 


### PR DESCRIPTION
With this modification you can use regexp in parent routes. (Notice lack of $ at end of regexp)


```go
sub := web.New()
sub.Use(middleware.SubRouter)
sub.Get("/get", func(c web.C, w http.ResponseWriter, req *http.Request) {
	fmt.Fprintf(w, "Info for IP address: %s", c.URLParams["ip"])
})
mux.Handle(regexp.MustCompile(`^/ip/(?P<ip>(?:\d{1,3}\.){3}\d{1,3})/info`), sub)
```