### PR TITLE
Disable SSLv3 by default

### DIFF
--- a/graceful/graceful.go
+++ b/graceful/graceful.go
@@ -90,7 +90,9 @@ func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error {
 	if addr == "" {
 		addr = ":https"
 	}
-	config := &tls.Config{}
+	config := &tls.Config{
+		MinVersion: tls.VersionTLS10
+	}
 	if srv.TLSConfig != nil {
 		*config = *srv.TLSConfig
 	}


### PR DESCRIPTION
Disable SSLv3 by default. To prevent POODLE vulnerability. Link https://www.tinfoilsecurity.com/poodle