### PR TITLE
Don't call log.Fatal when there's a problem closing the server. 

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -42,7 +42,7 @@ func Serve() {
 	err := graceful.Serve(listener, http.DefaultServeMux)
 
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	graceful.Wait()


### PR DESCRIPTION
On Windows, when closing the Goji server, sometimes I get:
AcceptEx tcp [::]:8000: use of closed network connection
and that causes calling log.Fatal (and os.Exit(1) inside of it) in goji.Serve()

I'd like to, however, be able to clean up any other resources used by my app before os.Exit is called. This can be easily achieved by replacing log.Fatal with log.Println (or even log.Panic, because it can be recovered).