### PR TITLE
Add 'String() string' to Pattern

### DIFF
--- a/web/pattern.go
+++ b/web/pattern.go
@@ -12,6 +12,10 @@ import (
 //
 // Built-in implementations of this interface are used to implement regular
 // expression and string matching.
+//
+// Inside of a handler, you can get the handler's Pattern like this:
+//         c.Env[web.MatchKey].(web.Match).Pattern
+// Where c has the type C.
 type Pattern interface {
 	// In practice, most real-world routes have a string prefix that can be
 	// used to quickly determine if a pattern is an eligible match. The
@@ -29,6 +33,10 @@ type Pattern interface {
 	// Run the pattern on the request and context, modifying the context as
 	// necessary to bind URL parameters or other parsed state.
 	Run(r *http.Request, c *C)
+	// String returns a string representation of Pattern that should be
+	// recognizable to the user. For example, for string-based Patterns,
+	// String will return the raw string that the user supplied.
+	String() string
 }
 
 const unknownPattern = `Unknown pattern type %T. See http://godoc.org/github.com/zenazn/goji/web#PatternType for a list of acceptable types.`

--- a/web/router_test.go
+++ b/web/router_test.go
@@ -63,6 +63,10 @@ func (t testPattern) Match(r *http.Request, c *C) bool {
 func (t testPattern) Run(r *http.Request, c *C) {
 }
 
+func (t testPattern) String() string {
+	return ""
+}
+
 var _ Pattern = testPattern{}
 
 func TestPatternTypes(t *testing.T) {
@@ -177,6 +181,10 @@ func (rs rsPattern) Run(_ *http.Request, _ *C) {
 
 func (rs rsPattern) ServeHTTP(_ http.ResponseWriter, _ *http.Request) {
 	rs.ichan <- rs.i
+}
+
+func (rs rsPattern) String() string {
+	return ""
 }
 
 var _ Pattern = rsPattern{}


### PR DESCRIPTION
I added a `String() string` method to `Pattern` so you can use `c.Env[web.MatchKey].(web.Match).Pattern.String()` to get the human-representation of a route, which you can use for debugging.

This is similar to `mux.CurrentRoute(req).GetName()` with gorilla.Mux.