### PR TITLE
router/mux: Added an unhandler and helpers

### DIFF
--- a/web/mux.go
+++ b/web/mux.go
@@ -135,16 +135,34 @@ func (m *Mux) Handle(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mALL, handler)
 }
 
+// Handle removes the handler when the pattern matches, regardless of
+// HTTP method.
+func (m *Mux) Unhandle(pattern PatternType) {
+	m.rt.unhandle(pattern, mALL)
+}
+
 // Connect dispatches to the given handler when the pattern matches and the HTTP
 // method is CONNECT.
 func (m *Mux) Connect(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mCONNECT, handler)
 }
 
+// Unconnect removes the handler when the pattern matches and the HTTP
+// method is CONNECT.
+func (m *Mux) Unconnect(pattern PatternType) {
+	m.rt.unhandle(pattern, mCONNECT)
+}
+
 // Delete dispatches to the given handler when the pattern matches and the HTTP
 // method is DELETE.
 func (m *Mux) Delete(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mDELETE, handler)
+}
+
+// Undelete removes the handler when the pattern matches and the HTTP
+// method is DELETE.
+func (m *Mux) Undelete(pattern PatternType) {
+	m.rt.unhandle(pattern, mDELETE)
 }
 
 // Get dispatches to the given handler when the pattern matches and the HTTP
@@ -158,10 +176,22 @@ func (m *Mux) Get(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mGET|mHEAD, handler)
 }
 
+// Unget removes the handler when the pattern matches and the HTTP
+// method is GET.
+func (m *Mux) Unget(pattern PatternType) {
+	m.rt.unhandle(pattern, mGET|mHEAD)
+}
+
 // Head dispatches to the given handler when the pattern matches and the HTTP
 // method is HEAD.
 func (m *Mux) Head(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mHEAD, handler)
+}
+
+// Unhead removes the handler when the pattern matches and the HTTP
+// method is HEAD.
+func (m *Mux) Unhead(pattern PatternType) {
+	m.rt.unhandle(pattern, mHEAD)
 }
 
 // Options dispatches to the given handler when the pattern matches and the HTTP
@@ -170,10 +200,22 @@ func (m *Mux) Options(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mOPTIONS, handler)
 }
 
+// Unoptions removes the handler when the pattern matches and the HTTP
+// method is OPTIONS.
+func (m *Mux) Unoptions(pattern PatternType) {
+	m.rt.unhandle(pattern, mOPTIONS)
+}
+
 // Patch dispatches to the given handler when the pattern matches and the HTTP
 // method is PATCH.
 func (m *Mux) Patch(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mPATCH, handler)
+}
+
+// Unpatch removes the handler when the pattern matches and the HTTP
+// method is PATCH.
+func (m *Mux) Unpatch(pattern PatternType) {
+	m.rt.unhandle(pattern, mPATCH)
 }
 
 // Post dispatches to the given handler when the pattern matches and the HTTP
@@ -182,16 +224,34 @@ func (m *Mux) Post(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mPOST, handler)
 }
 
+// Unpost removes the handler when the pattern matches and the HTTP
+// method is POST.
+func (m *Mux) Unpost(pattern PatternType) {
+	m.rt.unhandle(pattern, mPOST)
+}
+
 // Put dispatches to the given handler when the pattern matches and the HTTP
 // method is PUT.
 func (m *Mux) Put(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mPUT, handler)
 }
 
+// Unput removes the handler when the pattern matches and the HTTP
+// method is PUT.
+func (m *Mux) Unput(pattern PatternType) {
+	m.rt.unhandle(pattern, mPUT)
+}
+
 // Trace dispatches to the given handler when the pattern matches and the HTTP
 // method is TRACE.
 func (m *Mux) Trace(pattern PatternType, handler HandlerType) {
 	m.rt.handleUntyped(pattern, mTRACE, handler)
+}
+
+// Untrace removes the handler when the pattern matches and the HTTP
+// method is TRACE.
+func (m *Mux) Untrace(pattern PatternType) {
+	m.rt.unhandle(pattern, mTRACE)
 }
 
 // NotFound sets the fallback (i.e., 404) handler for this mux.

--- a/web/router_test.go
+++ b/web/router_test.go
@@ -35,7 +35,6 @@ func TestMethods(t *testing.T) {
 	m.Put("/", chHandler(ch, "PUT"))
 	m.Trace("/", chHandler(ch, "TRACE"))
 	m.Handle("/", chHandler(ch, "OTHER"))
-	m.Get("/somethingelse", chHandler(ch, "GET")) // For later
 
 	for _, method := range methods {
 		r, _ := http.NewRequest(method, "/", nil)
@@ -50,6 +49,24 @@ func TestMethods(t *testing.T) {
 			t.Errorf("Timeout waiting for method %q", method)
 		}
 	}
+}
+
+func TestUnmethods(t *testing.T) {
+	t.Parallel()
+	m := New()
+	ch := make(chan string, 1)
+
+	m.Connect("/", chHandler(ch, "CONNECT"))
+	m.Delete("/", chHandler(ch, "DELETE"))
+	m.Head("/", chHandler(ch, "HEAD"))
+	m.Get("/", chHandler(ch, "GET"))
+	m.Options("/", chHandler(ch, "OPTIONS"))
+	m.Patch("/", chHandler(ch, "PATCH"))
+	m.Post("/", chHandler(ch, "POST"))
+	m.Put("/", chHandler(ch, "PUT"))
+	m.Trace("/", chHandler(ch, "TRACE"))
+	m.Handle("/", chHandler(ch, "OTHER"))
+	m.Get("/somethingelse", chHandler(ch, "GET")) // For later
 
 	// Test the rolldown after Unhandle as well
 	m.Unhandle("/")


### PR DESCRIPTION
I needed to be able to remove routes on the fly (in conjunction with service discovery), so I added router.unhandler() to safely remove handlers from the router, and helper functions too. If there are any changes you'd prefer to see, please let me know.